### PR TITLE
Remove redundant xfce-polkit call in autostart

### DIFF
--- a/openbox/autostart
+++ b/openbox/autostart
@@ -4,9 +4,6 @@ nitrogen --restore
 ## xfce4-settings daemon
 xfsettingsd &
 
-## polkit agent
-/usr/lib/xfce-polkit/xfce-polkit &
-
 ## Start Compositing Manager
 exec compton &
 


### PR DESCRIPTION
Openbox runs the /etc/xdg/autostart folder on session launch. No need to call
xfce-polkit in ~/.config/openbox/autostart.

#### **`/usr/lib/openbox/openbox-autostart`**
```bash
...
# Run the XDG autostart stuff.  These are found in /etc/xdg/autostart and
# in $HOME/.config/autostart.  This requires PyXDG to be installed.
# See openbox-xdg-autostart --help for more details.
/usr/lib/openbox/openbox-xdg-autostart "$@"
```

Also fixes the [error popup](https://i.ibb.co/7RCV36k/scrot.png)